### PR TITLE
Add php-amqplib based RabbitMQ checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-cli
+FROM php:8.1-cli
 
 MAINTAINER Vitaliy Zhuk <zhuk2205@gmail.com>
 
@@ -17,11 +17,11 @@ RUN \
 RUN \
     apt-get install -y --no-install-recommends \
         librabbitmq-dev && \
-    docker-php-ext-install pdo pdo_mysql && \
+    docker-php-ext-install pdo pdo_mysql sockets && \
     printf '\n' | pecl install amqp-1.11.0 && \
     printf "\n" | pecl install redis && \
     yes | pecl install xdebug && \
-    docker-php-ext-enable amqp xdebug redis
+    docker-php-ext-enable amqp xdebug redis sockets
 
 # Configure XDebug
 RUN \

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-redis": "*",
         "ext-curl": "*",
         "ext-pdo": "*",
+        "ext-sockets": "*",
         "phpunit/phpunit": "~9.0",
         "phpmetrics/phpmetrics": "^2.0",
         "phpstan/phpstan": "~0.12.85",
@@ -52,7 +53,8 @@
         "elasticsearch/elasticsearch": "~7.0",
         "react/promise": "~2.3",
         "illuminate/database": "~6.20.12 | ~7.30.4 | ~8.22.1 | ~9.0",
-        "aws/aws-sdk-php": "~3.0"
+        "aws/aws-sdk-php": "~3.0",
+        "php-amqplib/php-amqplib": "^3.0"
     },
 
     "minimum-stability": "dev",

--- a/src/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheck.php
+++ b/src/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheck.php
@@ -1,0 +1,87 @@
+<?php /** @noinspection ALL */
+/** @noinspection ALL */
+/** @noinspection ALL */
+
+/*
+ * This file is part of the FiveLab Diagnostic package.
+ *
+ * (c) FiveLab <mail@fivelab.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace FiveLab\Component\Diagnostic\Check\RabbitMq\AmqpLib;
+
+use FiveLab\Component\Diagnostic\Check\CheckInterface;
+use FiveLab\Component\Diagnostic\Check\RabbitMq\RabbitMqConnectionParameters;
+use FiveLab\Component\Diagnostic\Result\Failure;
+use FiveLab\Component\Diagnostic\Result\ResultInterface;
+use FiveLab\Component\Diagnostic\Result\Success;
+use PhpAmqpLib\Connection\AMQPSocketConnection;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
+use PhpAmqpLib\Exception\AMQPIOException;
+
+/**
+ * Check connect to RabbitMQ
+ */
+class RabbitMqSocketConnectionCheck implements CheckInterface
+{
+    /**
+     * @var RabbitMqConnectionParameters
+     */
+    private RabbitMqConnectionParameters $connectionParameters;
+
+    /**
+     * Constructor.
+     *
+     * @param RabbitMqConnectionParameters $connectionParameters
+     */
+    public function __construct(RabbitMqConnectionParameters $connectionParameters)
+    {
+        $this->connectionParameters = $connectionParameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function check(): ResultInterface
+    {
+        if (!\extension_loaded('sockets')) {
+            return new Failure('ext-sockets is not installed.');
+        }
+
+        if (!\class_exists(AMQPSocketConnection::class)) {
+            return new Failure('php-amqplib/php-amqplib is not installed.');
+        }
+
+        try {
+            new AMQPSocketConnection(
+                $this->connectionParameters->getHost(),
+                $this->connectionParameters->getPort(),
+                $this->connectionParameters->getUsername(),
+                $this->connectionParameters->getPassword(),
+                $this->connectionParameters->getVhost()
+            );
+        } catch (AMQPConnectionClosedException $e) {
+            return new Failure($e->getMessage());
+        } catch (AMQPIOException $e) {
+            return new Failure($e->getMessage());
+        }
+
+        return new Success('Successfully connected to RabbitMQ');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtraParameters(): array
+    {
+        return [
+            'dsn'   => $this->connectionParameters->getDsn(false, true),
+            'vhost' => $this->connectionParameters->getVhost(),
+        ];
+    }
+}

--- a/src/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheck.php
+++ b/src/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheck.php
@@ -1,0 +1,83 @@
+<?php /** @noinspection ALL */
+/** @noinspection ALL */
+/** @noinspection ALL */
+
+/*
+ * This file is part of the FiveLab Diagnostic package.
+ *
+ * (c) FiveLab <mail@fivelab.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace FiveLab\Component\Diagnostic\Check\RabbitMq\AmqpLib;
+
+use FiveLab\Component\Diagnostic\Check\CheckInterface;
+use FiveLab\Component\Diagnostic\Check\RabbitMq\RabbitMqConnectionParameters;
+use FiveLab\Component\Diagnostic\Result\Failure;
+use FiveLab\Component\Diagnostic\Result\ResultInterface;
+use FiveLab\Component\Diagnostic\Result\Success;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPConnectionClosedException;
+use PhpAmqpLib\Exception\AMQPIOException;
+
+/**
+ * Check connect to RabbitMQ
+ */
+class RabbitMqStreamConnectionCheck implements CheckInterface
+{
+    /**
+     * @var RabbitMqConnectionParameters
+     */
+    private RabbitMqConnectionParameters $connectionParameters;
+
+    /**
+     * Constructor.
+     *
+     * @param RabbitMqConnectionParameters $connectionParameters
+     */
+    public function __construct(RabbitMqConnectionParameters $connectionParameters)
+    {
+        $this->connectionParameters = $connectionParameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function check(): ResultInterface
+    {
+        if (!\class_exists(AMQPStreamConnection::class)) {
+            return new Failure('php-amqplib/php-amqplib is not installed.');
+        }
+
+        try {
+            new AMQPStreamConnection(
+                $this->connectionParameters->getHost(),
+                $this->connectionParameters->getPort(),
+                $this->connectionParameters->getUsername(),
+                $this->connectionParameters->getPassword(),
+                $this->connectionParameters->getVhost()
+            );
+        } catch (AMQPConnectionClosedException $e) {
+            return new Failure($e->getMessage());
+        } catch (AMQPIOException $e) {
+            return new Failure($e->getMessage());
+        }
+
+        return new Success('Successfully connected to RabbitMQ');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtraParameters(): array
+    {
+        return [
+            'dsn'   => $this->connectionParameters->getDsn(false, true),
+            'vhost' => $this->connectionParameters->getVhost(),
+        ];
+    }
+}

--- a/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
+++ b/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
@@ -18,6 +18,7 @@ use FiveLab\Component\Diagnostic\Check\RabbitMq\RabbitMqConnectionParameters;
 use FiveLab\Component\Diagnostic\Result\Failure;
 use FiveLab\Component\Diagnostic\Result\Success;
 use FiveLab\Component\Diagnostic\Tests\Check\AbstractRabbitMqTestCase;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class RabbitMqSocketConnectionCheckTest extends AbstractRabbitMqTestCase
 {
@@ -30,8 +31,12 @@ class RabbitMqSocketConnectionCheckTest extends AbstractRabbitMqTestCase
             self::markTestSkipped('The RabbitMQ is not configured.');
         }
 
-        if (!\class_exists(\AMQPConnection::class)) {
-            self::markTestSkipped('The ext-amqp not installed.');
+        if (!\extension_loaded('sockets')) {
+            self::markTestSkipped('ext-sockets is not installed.');
+        }
+
+        if (!\class_exists(AMQPStreamConnection::class)) {
+            self::markTestSkipped('php-amqplib/php-amqplib is not installed.');
         }
     }
 

--- a/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
+++ b/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the FiveLab Diagnostic package.
+ *
+ * (c) FiveLab <mail@fivelab.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace FiveLab\Component\Diagnostic\Tests\Check\RabbitMq\AmqpLib;
+
+use FiveLab\Component\Diagnostic\Check\RabbitMq\AmqpLib\RabbitMqSocketConnectionCheck;
+use FiveLab\Component\Diagnostic\Check\RabbitMq\RabbitMqConnectionParameters;
+use FiveLab\Component\Diagnostic\Result\Failure;
+use FiveLab\Component\Diagnostic\Result\Success;
+use FiveLab\Component\Diagnostic\Tests\Check\AbstractRabbitMqTestCase;
+
+class RabbitMqSocketConnectionCheckTest extends AbstractRabbitMqTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        if (!$this->canTestingWithRabbitMq()) {
+            self::markTestSkipped('The RabbitMQ is not configured.');
+        }
+
+        if (!\class_exists(\AMQPConnection::class)) {
+            self::markTestSkipped('The ext-amqp not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSuccessGetExtraParams(): void
+    {
+        $check = new RabbitMqSocketConnectionCheck($this->getRabbitMqConnectionParameters());
+
+        self::assertEquals([
+            'dsn'   => $this->getRabbitMqConnectionParameters()->getDsn(false, true),
+            'vhost' => '/',
+        ], $check->getExtraParameters());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnOkIfSuccessConnect(): void
+    {
+        $check = new RabbitMqSocketConnectionCheck($this->getRabbitMqConnectionParameters());
+
+        $result = $check->check();
+
+        self::assertEquals(new Success('Successfully connected to RabbitMQ'), $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnFailIfPasswordIsWrong(): void
+    {
+        $connectionParameters = new RabbitMqConnectionParameters(
+            $this->getRabbitMqHost(),
+            $this->getRabbitMqPort(),
+            $this->getRabbitMqLogin(),
+            \uniqid(),
+            $this->getRabbitMqVhost()
+        );
+
+        $check = new RabbitMqSocketConnectionCheck($connectionParameters);
+
+        $result = $check->check();
+
+        self::assertEquals(
+            new Failure('ACCESS_REFUSED - Login was refused using authentication mechanism AMQPLAIN. For details see the broker logfile.(0, 0)'),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFailIfHostIsDown(): void
+    {
+        $connectionParameters = new RabbitMqConnectionParameters(
+            \uniqid(),
+            $this->getRabbitMqPort(),
+            $this->getRabbitMqLogin(),
+            $this->getRabbitMqPassword(),
+            $this->getRabbitMqVhost()
+        );
+
+        $check = new RabbitMqSocketConnectionCheck($connectionParameters);
+
+        $result = $check->check();
+
+        self::assertEquals(
+            new Failure('Error Connecting to server (-10001): Unknown host'),
+            $result
+        );
+    }
+}

--- a/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
+++ b/tests/Check/RabbitMq/AmqpLib/RabbitMqSocketConnectionCheckTest.php
@@ -105,9 +105,7 @@ class RabbitMqSocketConnectionCheckTest extends AbstractRabbitMqTestCase
 
         $result = $check->check();
 
-        self::assertEquals(
-            new Failure('Error Connecting to server (-10001): Unknown host'),
-            $result
-        );
+        self::assertInstanceOf(Failure::class, $result);
+        self::assertStringContainsString('Error Connecting to server', $result->getMessage());
     }
 }

--- a/tests/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheckTest.php
+++ b/tests/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheckTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the FiveLab Diagnostic package.
+ *
+ * (c) FiveLab <mail@fivelab.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace FiveLab\Component\Diagnostic\Tests\Check\RabbitMq\AmqpLib;
+
+use FiveLab\Component\Diagnostic\Check\RabbitMq\AmqpLib\RabbitMqStreamConnectionCheck;
+use FiveLab\Component\Diagnostic\Check\RabbitMq\RabbitMqConnectionParameters;
+use FiveLab\Component\Diagnostic\Result\Failure;
+use FiveLab\Component\Diagnostic\Result\Success;
+use FiveLab\Component\Diagnostic\Tests\Check\AbstractRabbitMqTestCase;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class RabbitMqStreamConnectionCheckTest extends AbstractRabbitMqTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        if (!$this->canTestingWithRabbitMq()) {
+            self::markTestSkipped('The RabbitMQ is not configured.');
+        }
+
+        if (!\class_exists(AMQPStreamConnection::class)) {
+            self::markTestSkipped('php-amqplib/php-amqplib is not installed.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSuccessGetExtraParams(): void
+    {
+        $check = new RabbitMqStreamConnectionCheck($this->getRabbitMqConnectionParameters());
+
+        self::assertEquals([
+            'dsn'   => $this->getRabbitMqConnectionParameters()->getDsn(false, true),
+            'vhost' => '/',
+        ], $check->getExtraParameters());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnOkIfSuccessConnect(): void
+    {
+        $check = new RabbitMqStreamConnectionCheck($this->getRabbitMqConnectionParameters());
+
+        $result = $check->check();
+
+        self::assertEquals(new Success('Successfully connected to RabbitMQ'), $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnFailIfPasswordIsWrong(): void
+    {
+        $connectionParameters = new RabbitMqConnectionParameters(
+            $this->getRabbitMqHost(),
+            $this->getRabbitMqPort(),
+            $this->getRabbitMqLogin(),
+            \uniqid(),
+            $this->getRabbitMqVhost()
+        );
+
+        $check = new RabbitMqStreamConnectionCheck($connectionParameters);
+
+        $result = $check->check();
+
+        self::assertEquals(
+            new Failure('ACCESS_REFUSED - Login was refused using authentication mechanism AMQPLAIN. For details see the broker logfile.(0, 0)'),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFailIfHostIsDown(): void
+    {
+        $connectionParameters = new RabbitMqConnectionParameters(
+            \uniqid(),
+            $this->getRabbitMqPort(),
+            $this->getRabbitMqLogin(),
+            $this->getRabbitMqPassword(),
+            $this->getRabbitMqVhost()
+        );
+
+        $check = new RabbitMqStreamConnectionCheck($connectionParameters);
+
+        $result = $check->check();
+
+        self::assertInstanceOf(Failure::class, $result);
+        self::assertStringContainsString('Name or service not known', $result->getMessage());
+    }
+}

--- a/tests/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheckTest.php
+++ b/tests/Check/RabbitMq/AmqpLib/RabbitMqStreamConnectionCheckTest.php
@@ -102,6 +102,7 @@ class RabbitMqStreamConnectionCheckTest extends AbstractRabbitMqTestCase
         $result = $check->check();
 
         self::assertInstanceOf(Failure::class, $result);
-        self::assertStringContainsString('Name or service not known', $result->getMessage());
+        self::assertStringContainsString('getaddrinfo', $result->getMessage());
+        self::assertStringContainsString('failed', $result->getMessage());
     }
 }


### PR DESCRIPTION
PHP 8.0->8.1 docker image upgrade is a necessary measure as ext-sockets is not compileable for php8, at least while using latest official debian based docker images.